### PR TITLE
PlaceモデルとReviewモデルの一対多の紐付け

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -4,7 +4,7 @@ class ResultsController < ApplicationController
   def create
     url = params[:url]
     place_data_scraper = MyTools::PlaceDataScraper.new(url)
-    place_id = place_data_scraper.save_place
-    place_data_scraper.save_review(place_id)
+    place = place_data_scraper.save_place
+    place_data_scraper.save_review(place.id)
   end
 end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -4,7 +4,7 @@ class ResultsController < ApplicationController
   def create
     url = params[:url]
     place_data_scraper = MyTools::PlaceDataScraper.new(url)
-    place_data_scraper.save_review
-    place_data_scraper.save_place
+    place_id = place_data_scraper.save_place
+    place_data_scraper.save_review(place_id)
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,5 +1,5 @@
 class Review < ApplicationRecord
-  belongs_to :place, optional: true
+  belongs_to :place
   validates :count, presence: true
   validates :star, presence: true
 end

--- a/db/migrate/20210302124316_create_reviews.rb
+++ b/db/migrate/20210302124316_create_reviews.rb
@@ -4,6 +4,7 @@ class CreateReviews < ActiveRecord::Migration[6.1]
       t.string :text, null: false
       t.integer :count, null: false
       t.float :star, null: false
+      t.references :place, index: true, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,18 +16,21 @@ ActiveRecord::Schema.define(version: 2021_03_02_124316) do
   enable_extension "plpgsql"
 
   create_table "places", force: :cascade do |t|
-    t.string "place_name"
-    t.string "address"
+    t.string "place_name", null: false
+    t.string "address", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "reviews", force: :cascade do |t|
-    t.string "text"
-    t.integer "count"
-    t.float "star"
+    t.string "text", null: false
+    t.integer "count", null: false
+    t.float "star", null: false
+    t.bigint "place_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["place_id"], name: "index_reviews_on_place_id"
   end
 
+  add_foreign_key "reviews", "places"
 end

--- a/lib/my_tools/place_data_scraper.rb
+++ b/lib/my_tools/place_data_scraper.rb
@@ -23,9 +23,7 @@ module MyTools
 
     def save_place
       result = @scrape_process.fetch_place
-      place =
-        Place.create(place_name: result[:place_name], address: result[:address])
-      return place.id
+      Place.create(place_name: result[:place_name], address: result[:address])
     end
   end
 end

--- a/lib/my_tools/place_data_scraper.rb
+++ b/lib/my_tools/place_data_scraper.rb
@@ -12,7 +12,7 @@ module MyTools
       results = @scrape_process.fetch_reviews
 
       results.each do |result|
-        Review.create!(
+        Review.create(
           text: result[:text],
           count: result[:count],
           star: result[:star],

--- a/lib/my_tools/place_data_scraper.rb
+++ b/lib/my_tools/place_data_scraper.rb
@@ -7,21 +7,25 @@ module MyTools
       @scrape_process = MyTools::SeleniumTool.new(@url)
     end
 
-    def save_review
+    #save_reviewがplace_idを受け取れるようにする
+    def save_review(place_id)
       results = @scrape_process.fetch_reviews
 
       results.each do |result|
-        Review.create(
+        Review.create!(
           text: result[:text],
           count: result[:count],
           star: result[:star],
+          place_id: place_id,
         )
       end
     end
 
     def save_place
       result = @scrape_process.fetch_place
-      Place.create(place_name: result[:place_name], address: result[:address])
+      place =
+        Place.create(place_name: result[:place_name], address: result[:address])
+      return place.id
     end
   end
 end


### PR DESCRIPTION
## やったこと
- PlaceモデルとReviewモデルの一対多の紐付け
  - ReviewモデルにてPlaceモデルへのoptional:trueの削除
  - ReviewテーブルにPlaceテーブルとの外部キーである「place_id」カラムを追加した
  - Reviewテーブルに保存する際にplace_idを渡す
## やった理由
- place_idを投げたら口コミの信憑性の度合いを返す関数を作るためにReviewモデルとPlaceモデルを適切に一対多で紐付ける必要があるため 

## 確認項目
- [x] Reviewモデルのoptional:trueを消してもReviewテーブルにレコードを保存できる
- [x] PlaceテーブルのidとReviewテーブルのplace_idが連動する形でデータが保存される

## Issue
Fix #6 