### PR TITLE
文字数50文字以上かつ投稿件数20件以上の投稿者に絞った場合の星評価を返す

### DIFF
--- a/app/views/results/create.html.erb
+++ b/app/views/results/create.html.erb
@@ -6,4 +6,5 @@
 <p>平均文字数：<%= @result.text_ave %></p>
 <p>信憑性度合い：<%= @result.credibility_rate %></p>
 <p>厳選された星評価：<%= @result.credible_star_ave %></p>
+<p>＊厳選された星評価＝文字数50文字以上かつ投稿件数20件以上の投稿者に絞った場合の星評価</p>
 <%= link_to "戻る",new_result_path %>

--- a/app/views/results/create.html.erb
+++ b/app/views/results/create.html.erb
@@ -4,7 +4,6 @@
 <p>平均投稿数：<%= @result.count_ave %></p>
 <p>平均星評価：<%= @result.star_ave %></p>
 <p>平均文字数：<%= @result.text_ave %></p>
-<p>信憑性度合い：<%= @result.credibility_rate %></p>
 <p>厳選された星評価：<%= @result.credible_star_ave %></p>
 <p>＊厳選された星評価＝文字数50文字以上かつ投稿件数20件以上の投稿者に絞った場合の星評価</p>
 <%= link_to "戻る",new_result_path %>

--- a/app/views/results/create.html.erb
+++ b/app/views/results/create.html.erb
@@ -5,4 +5,5 @@
 <p>平均星評価：<%= @result.star_ave %></p>
 <p>平均文字数：<%= @result.text_ave %></p>
 <p>信憑性度合い：<%= @result.credibility_rate %></p>
+<p>厳選された星評価：<%= @result.credible_star_ave %></p>
 <%= link_to "戻る",new_result_path %>

--- a/app/views/results/create.html.erb
+++ b/app/views/results/create.html.erb
@@ -4,4 +4,5 @@
 <p>平均投稿数：<%= @result.count_ave %></p>
 <p>平均星評価：<%= @result.star_ave %></p>
 <p>平均文字数：<%= @result.text_ave %></p>
+<p>信憑性度合い：<%= @result.credibility_rate %></p>
 <%= link_to "戻る",new_result_path %>

--- a/lib/my_tools/check_credibility.rb
+++ b/lib/my_tools/check_credibility.rb
@@ -22,7 +22,12 @@ module MyTools
       @star_ave = total / stars.length
       @count_ave = count_total / counts.length
       @text_ave = text_total / texts.length
-      @credibility_rate = '80%'
+
+      if @count_ave >= 20 and @text_ave >= 50
+        @credibility_rate = '高'
+      else
+        @credibility_rate = '低'
+      end
 
       return(
         Result.new(@place, @star_ave, @count_ave, @text_ave, @credibility_rate)

--- a/lib/my_tools/check_credibility.rb
+++ b/lib/my_tools/check_credibility.rb
@@ -13,7 +13,6 @@ module MyTools
           review if review.text.size >= 50 and review.count >= 20
         end
 
-      binding.pry
       puts '--------------------'
       puts puts_reviews
       puts '--------------------'

--- a/lib/my_tools/check_credibility.rb
+++ b/lib/my_tools/check_credibility.rb
@@ -6,6 +6,7 @@ module MyTools
 
     def credibility
       reviews = Review.where(place_id: @place_id)
+
       texts = reviews.map { |review| review.text }
       stars = reviews.map { |review| review.star }
       counts = reviews.map { |review| review.count }
@@ -13,6 +14,12 @@ module MyTools
       total = 0
       count_total = 0
       text_total = 0
+
+      puts_texts = texts.filter_map { |text| text.size if text.size >= 50 }
+      puts_counts = counts.filter { |count| count >= 20 }
+      puts '-----------------'
+      puts puts_counts
+      puts '-----------------'
 
       texts.each { |text| text_total = text_total + text.size }
       stars.each { |star| total = total + star }

--- a/lib/my_tools/check_credibility.rb
+++ b/lib/my_tools/check_credibility.rb
@@ -7,6 +7,16 @@ module MyTools
     def credibility
       reviews = Review.where(place_id: @place_id)
 
+      #口コミ文字数５０文字以上かつ投稿件数２０件以上を満たすReviewがほしい
+      puts_reviews =
+        reviews.filter_map do |review|
+          review if review.text.size >= 50 and review.count >= 20
+        end
+
+      binding.pry
+      puts '--------------------'
+      puts puts_reviews
+      puts '--------------------'
       texts = reviews.map { |review| review.text }
       stars = reviews.map { |review| review.star }
       counts = reviews.map { |review| review.count }
@@ -15,11 +25,8 @@ module MyTools
       count_total = 0
       text_total = 0
 
-      puts_texts = texts.filter_map { |text| text.size if text.size >= 50 }
-      puts_counts = counts.filter { |count| count >= 20 }
-      puts '-----------------'
-      puts puts_counts
-      puts '-----------------'
+      # puts_texts = texts.filter_map { |text| text.size if text.size >= 50 }
+      # puts_counts = counts.filter { |count| count >= 20 }
 
       texts.each { |text| text_total = text_total + text.size }
       stars.each { |star| total = total + star }

--- a/lib/my_tools/check_credibility.rb
+++ b/lib/my_tools/check_credibility.rb
@@ -8,21 +8,21 @@ module MyTools
       reviews = Review.where(place_id: @place_id)
 
       #口コミ文字数５０文字以上かつ投稿件数２０件以上を満たすReviewがほしい
-      puts_reviews =
+      selected_reviews =
         reviews.filter_map do |review|
           review if review.text.size >= 50 and review.count >= 20
         end
 
-      puts '--------------------'
-      puts puts_reviews
-      puts '--------------------'
       texts = reviews.map { |review| review.text }
       stars = reviews.map { |review| review.star }
       counts = reviews.map { |review| review.count }
+      selected_stars =
+        selected_reviews.map { |selected_review| selected_review.star }
 
       total = 0
       count_total = 0
       text_total = 0
+      selected_star_total = 0
 
       # puts_texts = texts.filter_map { |text| text.size if text.size >= 50 }
       # puts_counts = counts.filter { |count| count >= 20 }
@@ -30,11 +30,15 @@ module MyTools
       texts.each { |text| text_total = text_total + text.size }
       stars.each { |star| total = total + star }
       counts.each { |count| count_total = count_total + count }
+      selected_stars.each do |selected_star|
+        selected_star_total = selected_star_total + selected_star
+      end
 
       @place = Place.find_by(id: @place_id)
       @star_ave = total / stars.length
       @count_ave = count_total / counts.length
       @text_ave = text_total / texts.length
+      @credible_star_ave = selected_star_total / selected_stars.length
 
       if @count_ave >= 20 and @text_ave >= 50
         @credibility_rate = '高'
@@ -43,7 +47,14 @@ module MyTools
       end
 
       return(
-        Result.new(@place, @star_ave, @count_ave, @text_ave, @credibility_rate)
+        Result.new(
+          @place,
+          @star_ave,
+          @count_ave,
+          @text_ave,
+          @credibility_rate,
+          @credible_star_ave,
+        )
       )
     end
   end

--- a/lib/my_tools/check_credibility.rb
+++ b/lib/my_tools/check_credibility.rb
@@ -6,8 +6,6 @@ module MyTools
 
     def credibility
       reviews = Review.where(place_id: @place_id)
-
-      #口コミ文字数５０文字以上かつ投稿件数２０件以上を満たすReviewがほしい
       selected_reviews =
         reviews.filter_map do |review|
           review if review.text.size >= 50 and review.count >= 20
@@ -23,9 +21,6 @@ module MyTools
       count_total = 0
       text_total = 0
       selected_star_total = 0
-
-      # puts_texts = texts.filter_map { |text| text.size if text.size >= 50 }
-      # puts_counts = counts.filter { |count| count >= 20 }
 
       texts.each { |text| text_total = text_total + text.size }
       stars.each { |star| total = total + star }

--- a/lib/my_tools/check_credibility.rb
+++ b/lib/my_tools/check_credibility.rb
@@ -29,26 +29,26 @@ module MyTools
         selected_star_total = selected_star_total + selected_star
       end
 
-      @place = Place.find_by(id: @place_id)
-      @star_ave = total / stars.length
-      @count_ave = count_total / counts.length
-      @text_ave = text_total / texts.length
-      @credible_star_ave = selected_star_total / selected_stars.length
+      place = Place.find_by(id: @place_id)
+      star_ave = total / stars.length
+      count_ave = count_total / counts.length
+      text_ave = text_total / texts.length
+      credible_star_ave = selected_star_total / selected_stars.length
 
-      if @count_ave >= 20 and @text_ave >= 50
-        @credibility_rate = '高'
+      if count_ave >= 20 and text_ave >= 50
+        credibility_rate = '高'
       else
-        @credibility_rate = '低'
+        credibility_rate = '低'
       end
 
       return(
         Result.new(
-          @place,
-          @star_ave,
-          @count_ave,
-          @text_ave,
-          @credibility_rate,
-          @credible_star_ave,
+          place,
+          star_ave,
+          count_ave,
+          text_ave,
+          credibility_rate,
+          credible_star_ave,
         )
       )
     end

--- a/lib/my_tools/check_credibility.rb
+++ b/lib/my_tools/check_credibility.rb
@@ -33,7 +33,11 @@ module MyTools
       star_ave = total / stars.length
       count_ave = count_total / counts.length
       text_ave = text_total / texts.length
-      credible_star_ave = selected_star_total / selected_stars.length
+      begin
+        credible_star_ave = selected_star_total / selected_stars.length
+      rescue StandardError
+        credible_star_ave = '厳選された星評価基準を満たす投稿がありません'
+      end
 
       return Result.new(place, star_ave, count_ave, text_ave, credible_star_ave)
     end

--- a/lib/my_tools/check_credibility.rb
+++ b/lib/my_tools/check_credibility.rb
@@ -24,8 +24,11 @@ module MyTools
       @star_ave = total / stars.length
       @count_ave = count_total / counts.length
       @text_ave = text_total / texts.length
+      @credibility_rate = '80%'
 
-      return Result.new(@place, @star_ave, @count_ave, @text_ave)
+      return(
+        Result.new(@place, @star_ave, @count_ave, @text_ave, @credibility_rate)
+      )
     end
   end
 end

--- a/lib/my_tools/check_credibility.rb
+++ b/lib/my_tools/check_credibility.rb
@@ -35,22 +35,7 @@ module MyTools
       text_ave = text_total / texts.length
       credible_star_ave = selected_star_total / selected_stars.length
 
-      if count_ave >= 20 and text_ave >= 50
-        credibility_rate = '高'
-      else
-        credibility_rate = '低'
-      end
-
-      return(
-        Result.new(
-          place,
-          star_ave,
-          count_ave,
-          text_ave,
-          credibility_rate,
-          credible_star_ave,
-        )
-      )
+      return Result.new(place, star_ave, count_ave, text_ave, credible_star_ave)
     end
   end
 end

--- a/lib/my_tools/place_data_scraper.rb
+++ b/lib/my_tools/place_data_scraper.rb
@@ -11,7 +11,7 @@ module MyTools
       results = @scrape_process.fetch_reviews
       reviews = Review.find_by(place_id: place_id)
 
-      #place_idで探してきたReviewのレコードが既に存在したら既存のレコードを削除する
+      # place_idで探してきたReviewのレコードが既に存在したら既存のレコードを削除する
       Review.where(place_id: place_id).delete_all if reviews.present?
 
       results.each do |result|

--- a/lib/my_tools/place_data_scraper.rb
+++ b/lib/my_tools/place_data_scraper.rb
@@ -9,6 +9,10 @@ module MyTools
 
     def save_review(place_id)
       results = @scrape_process.fetch_reviews
+      reviews = Review.find_by(place_id: place_id)
+
+      #place_idで探してきたReviewのレコードが既に存在したら既存のレコードを削除する
+      Review.where(place_id: place_id).delete_all if reviews.present?
 
       results.each do |result|
         Review.create(

--- a/lib/my_tools/result.rb
+++ b/lib/my_tools/result.rb
@@ -5,23 +5,14 @@ module MyTools
                 :star_ave,
                 :count_ave,
                 :text_ave,
-                :credibility_rate,
                 :credible_star_ave
 
-    def initialize(
-      place,
-      star_ave,
-      count_ave,
-      text_ave,
-      credibility_rate,
-      credible_star_ave
-    )
+    def initialize(place, star_ave, count_ave, text_ave, credible_star_ave)
       @place_name = place.place_name
       @address = place.address
       @star_ave = star_ave
       @count_ave = count_ave
       @text_ave = text_ave
-      @credibility_rate = credibility_rate
       @credible_star_ave = credible_star_ave
     end
   end

--- a/lib/my_tools/result.rb
+++ b/lib/my_tools/result.rb
@@ -1,12 +1,18 @@
 module MyTools
   class Result
-    attr_reader :place_name, :address, :star_ave, :count_ave, :text_ave
-    def initialize(place, star_ave, count_ave, text_ave)
+    attr_reader :place_name,
+                :address,
+                :star_ave,
+                :count_ave,
+                :text_ave,
+                :credibility_rate
+    def initialize(place, star_ave, count_ave, text_ave, credibility_rate)
       @place_name = place.place_name
       @address = place.address
       @star_ave = star_ave
       @count_ave = count_ave
       @text_ave = text_ave
+      @credibility_rate = credibility_rate
     end
   end
 end

--- a/lib/my_tools/result.rb
+++ b/lib/my_tools/result.rb
@@ -5,15 +5,24 @@ module MyTools
                 :star_ave,
                 :count_ave,
                 :text_ave,
-                :credibility_rate
+                :credibility_rate,
+                :credible_star_ave
 
-    def initialize(place, star_ave, count_ave, text_ave, credibility_rate)
+    def initialize(
+      place,
+      star_ave,
+      count_ave,
+      text_ave,
+      credibility_rate,
+      credible_star_ave
+    )
       @place_name = place.place_name
       @address = place.address
       @star_ave = star_ave
       @count_ave = count_ave
       @text_ave = text_ave
       @credibility_rate = credibility_rate
+      @credible_star_ave = credible_star_ave
     end
   end
 end


### PR DESCRIPTION
## やったこと
- 文字数50文字以上かつ投稿件数20件以上の投稿者に絞った場合の星評価を返す
- place_idで探してきたReviewのレコードが既に存在したら既存のレコードを削除する
## やった理由
- 「文字数50文字以上かつ投稿件数20件以上」という基準をクリアした口コミに絞った場合の星評価を知りたいため
-  同一のplace_idを持つReviewレコードが重複して登録されないようにするため
## 確認項目
- [x]  place_idで絞ったReviewレコードに文字数50文字以上かつ投稿件数20件以上の投稿者に絞るfilter_map処理を行うことで条件を満たした口コミだけで算出した星評価を返す
- [x] place_idで探してきたReviewのレコードが既に存在したら既存のReviewレコードを削除して新たにReviewレコードを登録する