### PR TITLE
直近履歴から結果画面に遷移出来る

### DIFF
--- a/app/views/results/new.html.erb
+++ b/app/views/results/new.html.erb
@@ -8,5 +8,6 @@
     <p>店舗名：<%= history.place_name %></p>
     <p>平均星評価：<%= history.star_ave %></p>
     <p>厳選された星評価：<%= history.credible_star_ave %></p>
+    <%= link_to "詳細へ", result_path(history.result_id) %>
 <% end %>
 <p>＊厳選された星評価＝文字数50文字以上かつ投稿件数20件以上の投稿者に絞った場合の星評価</p>


### PR DESCRIPTION
## やったこと
- トップページの直近検索履歴をクリックすると実際の検索結果ページに飛ぶ

## やった理由
- HistoryクラスにResultのidを持たせているため、Resultのidを特定した`show.html.erb`（showメソッド）に飛ばしたかったから
## 確認項目
- [x] 「詳細へ」ボタンを押すと検索結果ページに遷移出来る

## Issue
Fix #50
