### PR TITLE
check_credibility.rbをcredibility_checker.rbに名前変更

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -46,8 +46,8 @@ class ResultsController < ApplicationController
       place_data_scraper.save_review(place_id)
       @place = place_data_scraper.save_place
       user_id = session[:user_id]
-      check_credibility = MyTools::CheckCredibility.new(place_id)
-      @result = check_credibility.credibility(user_id)
+      credibility_checker = MyTools::CredibilityChecker.new(place_id)
+      @result = credibility_checker.check(user_id)
       redirect_to result_path(@result)
     elsif @url.exclude?('www.google.com') && !url_validator.validate
       redirect_to root_path, notice: '不正なURLです'

--- a/lib/my_tools/credibility_checker.rb
+++ b/lib/my_tools/credibility_checker.rb
@@ -1,12 +1,12 @@
 module MyTools
-  class CheckCredibility
+  class CredibilityChecker
     attr_reader :place_id
 
     def initialize(place_id)
       @place_id = place_id
     end
 
-    def credibility(user_id)
+    def check(user_id)
       reviews = Review.where(place_id: @place_id)
 
       selected_reviews =


### PR DESCRIPTION
## やったこと
- check_credibility.rbをcredibility_checker.rbに名前変（クラス名変更）
- 付随して当該ファイルのcredibilityメソッドも「checkメソッド」に変更
## やった理由
- クラス名は実態そのものを表すのが正しいため、`check_credibility.rb`のようにcheckという動詞から始まるのはおかしい
- 上記に付随してメソッド名は通常、動詞から始まることが一般的であるため、credibilityメソッドを「checkメソッド」に変更した
## 確認項目
-[x] credibility_checker.rbにファイル名変更、当該ファイルのクラス名・メソッド名変更、当該クラス・メソッドの呼び出し元であるresults_controller.rbの当該箇所を正しい命名規則に変更しても正常に挙動する
## Issue
Fix #43
