### PR TITLE
URL遷移の適切化

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -49,7 +49,9 @@ class ResultsController < ApplicationController
         user_id = session[:user_id]
         check_credibility = MyTools::CheckCredibility.new(place_id)
         @result = check_credibility.credibility(user_id)
-        redirect_to action: 'create'
+
+        redirect_to result_path(@result)
+        # redirect_to action: 'create'
       rescue StandardError
         redirect_to root_path, notice: '口コミの取得に失敗しました'
       end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -49,7 +49,7 @@ class ResultsController < ApplicationController
         user_id = session[:user_id]
         check_credibility = MyTools::CheckCredibility.new(place_id)
         @result = check_credibility.credibility(user_id)
-        redirect_to result_path(@result)
+        redirect_to action: 'create'
       rescue StandardError
         redirect_to root_path, notice: '口コミの取得に失敗しました'
       end


### PR DESCRIPTION
## やったこと
### 問題点
- トップページから口コミURLを入力して検索ボタンをクリックすると、`http://localhost:3000/results/190←整数部分は可変のid`に遷移していた（`show.html.erb`が表示されていた）
- 本来であれば`results_controller.rb`の`new`メソッド（トップページ、`new.html.erb`）が呼ばれた後、`create`メソッドが呼ばれて口コミの精査をして`create.html.erb`に遷移するのが適切
- `results_controller.rb`の`show`メソッド（show.html.erb）はトップページやログイン後の検索履歴の概要から特定の施設名をクリックした際に遷移させたいページ（当該施設の検索結果の詳細を閲覧出来るページ）
```
【理想のURL遷移】
口コミURLを入力して検索→createメソッドが呼ばれ`create.html.erb`が表示される
【現時点でのURL遷移】
- 口コミURLを入力して検索→createメソッドが呼ばれるが最終的に表示されるのは`show.html.erb`
- `show.html.erb`が表示されるのはあくまでもトップページやログイン後の検索履歴の概要から特定の施設名をクリックした時
```
## やった理由

## 確認項目
-[ ]

## スクリーンショット

## Issue
Fix #
