### PR TITLE
コントローラーでのクラス名書き間違い修正

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -47,8 +47,8 @@ class ResultsController < ApplicationController
         place_data_scraper.save_review(place_id)
         @place = place_data_scraper.save_place
         user_id = session[:user_id]
-        check_credibility = MyTools::CheckCredibility.new(place_id)
-        @result = check_credibility.credibility(user_id)
+        check_credibility = MyTools::CredibilityChecker.new(place_id)
+        @result = check_credibility.check(user_id)
         redirect_to result_path(@result)
       rescue StandardError
         redirect_to root_path, alert: '口コミの取得に失敗しました'


### PR DESCRIPTION
## やったこと
- results_controller.rbで`CredibilityChecker`クラスが`CheckCredibility`クラスとして呼ばれていたため、`CredibilityChecker`に書き直した
- `CredibilityChecker`で設定しているメソッド名も`check`メソッドが正しいのに`credibility`メソッドとなっていたため書き直した
## やった理由
- mainブランチで口コミURLを入力して調査ボタンを押すとスクレイピングは正常に行えているのに「口コミの取得に失敗しました」とエラーが出てトップページにリダイレクトされた
- 上記事象からresults_controller.rbのcreateメソッドにおけるbegin~rescue周りの設定がおかしいと考え、クラス名の呼び間違いを発見した
## 確認項目
- [x] 口コミURLを入力して調査ボタンを押すと調査結果が表示される