### PR TITLE
Googleの検索画面（「Googleの口コミ」ボタンはある）URLを入力すると「口コミの取得に失敗しましたとエラーが出る

### DIFF
--- a/lib/my_tools/place_data_scraper.rb
+++ b/lib/my_tools/place_data_scraper.rb
@@ -4,8 +4,8 @@ module MyTools
 
     def initialize(url)
       #TODO: URLを二重管理しているのでなんとかする https://github.com/pekorinko/review_check/issues/71
-      @url = url
-      @scrape_process = MyTools::SeleniumTool.new(@url)
+      @scrape_process = MyTools::SeleniumTool.new(url)
+      @url = @scrape_process.url
     end
 
     def save_review(place_id)


### PR DESCRIPTION
## やったこと
- `place_data_scraper.rb`のinitializeメソッドにおいてコードの順番にミスがあったことが本エラーの原因
- ` @scrape_process = MyTools::SeleniumTool.new(@url)`をした上で`@url = url`に代入しないと口コミモーダル取得後のURLを`place_data_scraper.rb`のinitializeメソッドに知らせることが出来ない
```
【修正前】
def initialize(url)
      #TODO: URLを二重管理しているのでなんとかする https://github.com/pekorinko/review_check/issues/71
      @url = url
      @scrape_process = MyTools::SeleniumTool.new(@url)
end
```
```
【修正後】
def initialize(url)
      #TODO: URLを二重管理しているのでなんとかする https://github.com/pekorinko/review_check/issues/71
      @scrape_process = MyTools::SeleniumTool.new(url)
      @url = @scrape_process.url
end
```
## やった理由
- Googleの検索画面（「Googleの口コミ」ボタンはある）URLを入力すると「口コミの取得に失敗しましたとエラーが出てしまったため
## 確認項目
- [x] Googleの検索画面URLを入力すると「Googleの口コミ」ボタンを自動で押して口コミモーダルを出現させ、モーダルのURLを用いてスクレイピングを行い、調査結果結果画面を表示する
## Issue
Fix #89
