### PR TITLE
mainブランチに反映漏れのあった差分を解消する

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :authenticate
+
   def create
     user = User.find_or_create_from_auth_hash!(request.env['omniauth.auth'])
     session[:user_id] = user.id

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,3 +1,4 @@
 class Result < ApplicationRecord
   belongs_to :place
+  belongs_to :user, optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :results
+
   def self.find_or_create_from_auth_hash!(auth_hash)
     provider = auth_hash[:provider]
     uid = auth_hash[:uid]

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,8 +4,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
              Rails.application.credentials.github[:client_id_dev],
              Rails.application.credentials.github[:client_secret_dev]
   else
-    provider :github,
-             Rails.application.credentials.github[:client_id],
-             Rails.application.credentials.github[:client_secret]
+    provider :github, ENV['GITHUB_CLIENT_ID'], ENV['GITHUB_CLIENT_SECRET']
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,17 @@
+class AuthenticatedConstraint
+  def matches?(request)
+    request.session['user_id'].present?
+  end
+end
+
 Rails
   .application
   .routes
   .draw do
+    constraints AuthenticatedConstraint.new do
+      root to: 'results#index', as: :user_root
+    end
+
     root 'results#new'
     get '/auth/:provider/callback' => 'sessions#create'
     delete '/logout' => 'sessions#destroy'

--- a/db/migrate/20210429023145_add_references_to_results2.rb
+++ b/db/migrate/20210429023145_add_references_to_results2.rb
@@ -1,0 +1,5 @@
+class AddReferencesToResults2 < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :results, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,13 +27,13 @@ ActiveRecord::Schema.define(version: 2021_05_23_111332) do
   end
 
   create_table "results", force: :cascade do |t|
-    t.float "star_ave"
     t.integer "count_ave"
     t.integer "text_ave"
     t.float "credible_star_ave"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "place_id"
+    t.float "star_ave"
     t.bigint "user_id"
     t.index ["place_id"], name: "index_results_on_place_id"
     t.index ["user_id"], name: "index_results_on_user_id"

--- a/lib/my_tools/search_history.rb
+++ b/lib/my_tools/search_history.rb
@@ -1,0 +1,16 @@
+module MyTools
+  class SearchHistory
+    attr_reader :result_id,
+                :place_id,
+                :place_name,
+                :star_ave,
+                :credible_star_ave
+    def initialize(result_id, place_id, place_name, star_ave, credible_star_ave)
+      @result_id = result_id
+      @place_id = place_id
+      @place_name = place_name
+      @star_ave = star_ave
+      @credible_star_ave = credible_star_ave
+    end
+  end
+end

--- a/lib/my_tools/selenium_tool.rb
+++ b/lib/my_tools/selenium_tool.rb
@@ -12,7 +12,7 @@ module MyTools
       # モーダルが来ても検索結果が来てもページが表示されたか判別出来るなにかをする
       # begin rescueを使ってタイムアウトしたということは検索画面URLだったと判断する
       begin
-        wait.until { @driver.find_element(:class_name, 'lcorif').displayed? }
+        @wait.until { @driver.find_element(:class_name, 'lcorif').displayed? }
       rescue StandardError
         replace_url_if_needed
       end
@@ -114,7 +114,7 @@ module MyTools
           .find_element(:class_name, 'review-score-container')
           .find_element(:class_name, 'Aq14fc')
           .text
-      
+
       facility = @driver.find_element(:class_name, 'VUGnzb')
       facility_name = facility.find_element(:class_name, 'P5Bobd').text
       address = facility.find_element(:class_name, 'T6pBCe').text


### PR DESCRIPTION
## やった理由
- ブランチ整理の過程でステージングし忘れや誤ってファイル削除してしまったことによりmainブランチに本来あるべきファイルやコードが無い自体が発生していたため
## 確認項目
- [x] ResultとUserの関連付け漏れ解消
- [x] search_histroy.rbの再作成
- [x] sessions_controller.rbにおけるskip_before_actionの設定漏れ解消
- [x] ログイン関係の設定漏れ解消（ログイン用のルーティング・本番環境用のclient_idとclient_secret設定） 