### PR TITLE
Herokuで動かすための設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rails', '~> 6.1.3.2'
 gem 'pg', '~> 1.1'
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
+gem "puma_worker_killer"
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
     ffi (1.14.2)
+    get_process_mem (0.2.7)
+      ffi (~> 1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashie (4.1.0)
@@ -149,6 +151,9 @@ GEM
     public_suffix (4.0.6)
     puma (5.2.1)
       nio4r (~> 2.0)
+    puma_worker_killer (0.3.1)
+      get_process_mem (~> 0.2)
+      puma (>= 2.7)
     racc (1.5.2)
     rack (2.2.3)
     rack-mini-profiler (2.3.1)
@@ -256,6 +261,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 5.0)
+  puma_worker_killer
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3.2)
   sass-rails (>= 6)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -32,7 +32,7 @@ class ResultsController < ApplicationController
   end
 
   def create
-    @url = params[:url]
+    @url = localized_url(params[:url])
 
     url_filter = MyTools::UrlFilter.new(@url)
     @url = url_filter.filter
@@ -58,5 +58,13 @@ class ResultsController < ApplicationController
     else
       redirect_to root_path, alert: '不正なURLです'
     end
+  end
+
+  private
+
+  def localized_url(url)
+    a, b = url.split('#')
+    localized_query = '&gl=jp&hl=ja&gws_rd=cr&pws=0'
+    a + localized_query + '#' + b
   end
 end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -41,11 +41,12 @@ class ResultsController < ApplicationController
 
     if url_validator.valid?
       begin
-        place_data_scraper = MyTools::PlaceDataScraper.new(@url)
-        place = place_data_scraper.save_place
+        @place_data_scraper = MyTools::PlaceDataScraper.new(@url)
+        place = @place_data_scraper.save_place
         place_id = place.id
-        place_data_scraper.save_review(place_id)
-        @place = place_data_scraper.save_place
+        @place_data_scraper.save_review(place_id)
+        @place = @place_data_scraper.save_place
+        @place_data_scraper.quit
         user_id = session[:user_id]
         check_credibility = MyTools::CredibilityChecker.new(place_id)
         @result = check_credibility.check(user_id)
@@ -53,6 +54,7 @@ class ResultsController < ApplicationController
       rescue StandardError => e
         logger.error(e.inspect)
         logger.error(e.backtrace.join("\n"))
+        @place_data_scraper.quit
         redirect_to root_path, alert: '口コミの取得に失敗しました'
       end
     else

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -50,7 +50,9 @@ class ResultsController < ApplicationController
         check_credibility = MyTools::CredibilityChecker.new(place_id)
         @result = check_credibility.check(user_id)
         redirect_to result_path(@result)
-      rescue StandardError
+      rescue StandardError => e
+        logger.error(e.inspect)
+        logger.error(e.backtrace.join("\n"))
         redirect_to root_path, alert: '口コミの取得に失敗しました'
       end
     else

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,25 +4,25 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 #
-worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch('PORT') { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV') { 'development' }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together
@@ -31,6 +31,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # processes).
 #
 # workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/lib/my_tools/place_data_scraper.rb
+++ b/lib/my_tools/place_data_scraper.rb
@@ -48,5 +48,8 @@ module MyTools
         star_ave: @result[:star_ave],
       )
     end
+    def quit
+      @scrape_process.quit
+    end
   end
 end

--- a/lib/my_tools/selenium_tool.rb
+++ b/lib/my_tools/selenium_tool.rb
@@ -5,7 +5,24 @@ module MyTools
       @url = url
       options = Selenium::WebDriver::Chrome::Options.new
       options.add_argument('--headless')
-      @driver = Selenium::WebDriver.for :chrome, options: options
+      caps =
+        if Rails.env.production?
+          Selenium::WebDriver::Remote::Capabilities.chrome(
+            'chromeOptions' => {
+              binary: ENV['GOOGLE_CHROME_SHIM'],
+              args: %w[--headless --disable-gpu window-size=1280x800],
+            },
+          )
+        end
+      if Rails.env.production?
+        @driver =
+          Selenium::WebDriver.for :chrome,
+                                  options: options,
+                                  desired_capabilities: caps
+      else
+        @driver = Selenium::WebDriver.for :chrome, options: options
+      end
+
       @wait = Selenium::WebDriver::Wait.new(timeout: 30)
       @driver.get(@url)
 
@@ -114,7 +131,7 @@ module MyTools
           .find_element(:class_name, 'review-score-container')
           .find_element(:class_name, 'Aq14fc')
           .text
-      
+
       facility = @driver.find_element(:class_name, 'VUGnzb')
       facility_name = facility.find_element(:class_name, 'P5Bobd').text
       address = facility.find_element(:class_name, 'T6pBCe').text

--- a/lib/my_tools/selenium_tool.rb
+++ b/lib/my_tools/selenium_tool.rb
@@ -58,6 +58,10 @@ module MyTools
       end
     end
 
+    def quit
+      @driver.quit
+    end
+
     def get_review_count(local_guide)
       if local_guide.find_elements(:class_name, 'A503be').size > 0
         local_guide_info = local_guide.find_element(:class_name, 'A503be')

--- a/lib/my_tools/selenium_tool.rb
+++ b/lib/my_tools/selenium_tool.rb
@@ -16,6 +16,7 @@ module MyTools
                 window-size=1280x800
                 --no-sandbox
                 --disable-dev-shm-usage
+                --enable-features=NetworkService,NetworkServiceInProcess
               ],
             },
           )

--- a/lib/my_tools/selenium_tool.rb
+++ b/lib/my_tools/selenium_tool.rb
@@ -10,7 +10,13 @@ module MyTools
           Selenium::WebDriver::Remote::Capabilities.chrome(
             'chromeOptions' => {
               binary: ENV['GOOGLE_CHROME_SHIM'],
-              args: %w[--headless --disable-gpu window-size=1280x800],
+              args: %w[
+                --headless
+                --disable-gpu
+                window-size=1280x800
+                --no-sandbox
+                --disable-dev-shm-usage
+              ],
             },
           )
         end

--- a/lib/my_tools/selenium_tool.rb
+++ b/lib/my_tools/selenium_tool.rb
@@ -29,7 +29,7 @@ module MyTools
         @driver = Selenium::WebDriver.for :chrome, options: options
       end
 
-      @wait = Selenium::WebDriver::Wait.new(timeout: 30)
+      @wait = Selenium::WebDriver::Wait.new(timeout: 13)
       @driver.get(@url)
 
       # モーダルが来ても検索結果が来てもページが表示されたか判別出来るなにかをする
@@ -51,7 +51,6 @@ module MyTools
         @driver.execute_script(
           'document.getElementsByClassName("hqzQac")[0].getElementsByTagName("a")[0].click()',
         )
-        sleep 5
         @url = @driver.current_url
         @driver.get(@url)
         @wait.until { @driver.find_element(:class_name, 'lcorif').displayed? }


### PR DESCRIPTION
## やったこと
- Heroku上でSeleniumを動かすための設定
- Profileの作成
- 口コミ取得失敗エラーをログに書き出す
- Herokuで起こったR14エラーの応急処置
  - puma_worker_killerの導入
  - `config/puma.rb`に`workers Integer(ENV['WEB_CONCURRENCY'] || 2)`を書き加えてherokuにpushした後、`$ heroku config:set WEB_CONCURRENCY=1` を実行してwokerの起動数を変更 
  - 関連issue https://github.com/pekorinko/review_check/issues/102#issuecomment-862299288
- Heroku（アメリカ）から日本のGoogleを使うための処理追加
  - URLに特別にパラメータを付与しないとSeleniumが英語版のGoogleを見に行ってしまうため
- chrome_optionsに`--no-sandbox`と`--disable-dev-shm-usage`と`--enable-features=NetworkService,NetworkServiceInProcess`追加
  - 関連issue https://github.com/pekorinko/review_check/issues/105#issue-925251761 
- WebDriverを作った後、quitで後始末する
  - 参考記事：https://qiita.com/nsuhara/items/76ae132734b7e2b352dd
## 確認項目
- [x] Heroku上でもスクレイピングできる