### PR TITLE
口コミボタンはあるが口コミモーダルではないページのURLでもスクレイピングできる

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -54,7 +54,6 @@ class ResultsController < ApplicationController
       rescue StandardError => e
         logger.error(e.inspect)
         logger.error(e.backtrace.join("\n"))
-        @place_data_scraper.quit
         redirect_to root_path, alert: '口コミの取得に失敗しました'
       end
     else

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -65,8 +65,13 @@ class ResultsController < ApplicationController
   private
 
   def localized_url(url)
-    a, b = url.split('#')
-    localized_query = '&gl=jp&hl=ja&gws_rd=cr&pws=0'
-    a + localized_query + '#' + b
+    if url.include?('#')
+      a, b = url.split('#')
+      localized_query = '&gl=jp&hl=ja&gws_rd=cr&pws=0'
+      a + localized_query + '#' + b
+    else
+      localized_query = '&gl=jp&hl=ja&gws_rd=cr&pws=0'
+      url.to_s + localized_query
+    end
   end
 end

--- a/lib/my_tools/selenium_tool.rb
+++ b/lib/my_tools/selenium_tool.rb
@@ -30,7 +30,7 @@ module MyTools
         @driver = Selenium::WebDriver.for :chrome, options: options
       end
 
-      @wait = Selenium::WebDriver::Wait.new(timeout: 13)
+      @wait = Selenium::WebDriver::Wait.new(timeout: 10)
       @driver.get(@url)
 
       # モーダルが来ても検索結果が来てもページが表示されたか判別出来るなにかをする


### PR DESCRIPTION
## やったこと
- Seleniumの待ち時間を13秒から10秒に変更（HerokuのエラーH12解消目的）
- Herokuから日本のGoogleを見るためのパラメータ付与処理をGoogleの検索結果URL、GoogleMapの一覧URLでも行えるようにする
- Googleの口コミが無いURLの場合は「口コミの取得に失敗しました」アラートを出すためにrescue節の`@place_data_scraper.quit`を削除
## やった理由
- 口コミボタンはあるが口コミモーダルではないページのURLでもスクレイピングできるようにするため
- Googleの口コミが無いURLの場合は「口コミの取得に失敗しました」アラートを出すようにするため
## 確認項目
- [x] 口コミボタンがあるGoogleの検索結果・GoogleMapの一覧画面からでもスクレイピングできる
- [x]  Googleの口コミが無いURLの場合は「口コミの取得に失敗しました」アラートが出る
## Issue
Fix #105 
